### PR TITLE
Bump maven-libs.version from 3.8.1 to 3.8.3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         java: [ 8, 11 ]
         java_dist: ["adopt"]
-        maven: [ "3.6.3", "3.5.4", "3.3.9", "3.8.1" ]
+        maven: [ "3.6.3", "3.5.4", "3.3.9", "3.8.3" ]
       fail-fast: false
 
     services:

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire.excludes.files>**/*ExternalDatabaseTest.java</surefire.excludes.files>
-        <maven-libs.version>3.8.1</maven-libs.version>
+        <maven-libs.version>3.8.3</maven-libs.version>
         <maven-libs.annotations.version>3.6.1</maven-libs.annotations.version>
         <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>


### PR DESCRIPTION
Bumps  from 3.8.1 to 3.8.3.

- Updates `maven-core` from 3.8.1 to 3.8.3
- Updates `maven-compat` from 3.8.1 to 3.8.3

closes #258 