### PR TITLE
Bump maven from 3.9.4 to 3.9.5

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:16-3.3
+        image: postgis/postgis:16-3.4
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,18 +20,18 @@ jobs:
       matrix:        
         java: [ 8, 11 ]
         java_dist: ["temurin"]
-        maven: [ "3.5.4", "3.6.3", "3.8.8", "3.9.4" ]
+        maven: [ "3.5.4", "3.6.3", "3.8.8", "3.9.5" ]
         include:
           - java: 17
             java_dist: "temurin"
-            maven: "3.9.4"
+            maven: "3.9.5"
           - java: 21
             java_dist: "temurin"
-            maven: "3.9.4"
+            maven: "3.9.5"
 
     services:
       postgres:
-        image: postgis/postgis:15-3.3
+        image: postgis/postgis:16-3.3
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
             java_dist: "temurin"
             maven: "3.9.5"
           - java: 21
-            java_dist: "temurin"
+            java_dist: "zulu"
             maven: "3.9.5"
 
     services:

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire.excludes.files>**/*ExternalDatabaseTest.java</surefire.excludes.files>
-        <maven-libs.version>3.9.4</maven-libs.version>
+        <maven-libs.version>3.9.5</maven-libs.version>
         <maven-libs.annotations.version>3.9.0</maven-libs.annotations.version>
         <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
         <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>


### PR DESCRIPTION
Bumps `maven-libs.version` from 3.9.4 to 3.9.5.
Update CI to use 3.9.5.