### PR TITLE
Fix for code scanning alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: 'CodeQL'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release' ) && format('ci-master-{0}', github.sha) || format('ci-master-{0}', github.ref) }}
   cancel-in-progress: true

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,8 @@
 name: 'Repository Maintenance'
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '19 0 * * 1'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -83,6 +83,8 @@ jobs:
   docs:
     name: Check Javadoc for Java 17
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     name: "Test Java  ${{ matrix.java }} / Maven ${{ matrix.maven }}"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     strategy:
       fail-fast: false
       matrix:        

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,5 +1,8 @@
 name: 'OWASP dependency check'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release' ) && format('ci-master-{0}', github.sha) || format('ci-master-{0}', github.ref) }}
   cancel-in-progress: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     name: 'Update release Draft'
     steps:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,5 +1,9 @@
 name: 'Maven Site'
 
+permissions:
+  contents: read
+  pages: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release' ) && format('ci-master-{0}', github.sha) || format('ci-master-{0}', github.ref) }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fixes for:
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/279
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/280
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/281
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/282
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/283
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/284
- https://github.com/GeoDienstenCentrum/schemaspy-maven-plugin/security/code-scanning/285

To fix the issues, we will add a `permissions` block to the workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
