### PR TITLE
Update coveralls-maven-plugin groupId and version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,22 +232,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.eluder.coveralls</groupId>
+                    <groupId>com.github.hazendaz.maven</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
-                    <version>4.3.0</version>
-                    <dependencies>
-                        <!-- needed on java >11 -->
-                        <dependency>
-                            <groupId>jakarta.xml.bind</groupId>
-                            <artifactId>jakarta.xml.bind-api</artifactId>
-                            <version>2.3.3</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.glassfish.jaxb</groupId>
-                            <artifactId>jaxb-runtime</artifactId>
-                            <version>2.3.9</version>
-                        </dependency>
-                    </dependencies>
+                    <version>5.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
@@ -739,7 +726,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.eluder.coveralls</groupId>
+                        <groupId>com.github.hazendaz.maven</groupId>
                         <artifactId>coveralls-maven-plugin</artifactId>
                         <configuration>
                             <jacocoReports>


### PR DESCRIPTION
Updated coveralls-maven-plugin to version 5.0.0 and changed groupId.

see https://github.com/hazendaz/coveralls-maven-plugin